### PR TITLE
Updated flutter_svg from ^0.17.4 to ^0.18.1 #28 (second Issue)

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   cached_network_image: ^2.1.0+1
   fluttertoast: ^4.0.1
   path: any
-  flutter_svg: ^0.17.4
+  flutter_svg: ^0.18.1
 
 
 dev_dependencies:


### PR DESCRIPTION
Changed the version from flutter_svg from version 0.17.4 to 0.18.1 because of the [second Question](https://github.com/googlecodelabs/photos-sharing/issues/28#issuecomment-731016622) from Issue number 28